### PR TITLE
Mapping was changed to collections.abc

### DIFF
--- a/convert2folia/dataalign.py
+++ b/convert2folia/dataalign.py
@@ -288,7 +288,7 @@ class MWEAnnotMetadata(Metadata):
 
 ############################################################
 
-class Token(collections.Mapping):
+class Token(collections.abc.Mapping):
     r"""Represents a token in an input file.
 
     Instances behave like a frozen dict, so you can do


### PR DESCRIPTION
From Python 3.11, it throws an error:
module 'collections' has no attribute 'Mapping' 

A correction has been made to the line 291 in the file convert2folia/dataalign.py as indicated below:
collections.Mapping --> collections.abc.Mapping

This change is only validated from python 3.3 (https://docs.python.org/3.3/library/collections.abc.html)